### PR TITLE
Update ack section (#43)

### DIFF
--- a/drafts/latest/index.html
+++ b/drafts/latest/index.html
@@ -1720,14 +1720,26 @@ A property which is not mentioned but would be applicable for a class according 
 <h2>Acknowledgements</h2>
 
 <aside class="ednote">
-<p>Representatives, editors and contributors to be added.</p>
+<p>Representatives, editors and contributors to be updated.</p>
 </aside>
 
+<!--
 <p>This work was elaborated by a Working Group under the ISA² programme. The ISA² Programme of the European Commission was represented by <strong>TBD</strong>. <strong>TBD</strong> were the editors of the specification. Contributors: TBD.</p>
 <p>The members of the Working Group:</p>
 
 <div data-include-format="html" data-include-replace="true" data-include="./tables/geodcat-ap-wg-members.html"></div>
-
+-->
+<p>
+  This work was elaborated by the <a href="https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/solution/geodcat-application-profile-data-portals-europe/members">GeoDCAT-AP Working Group</a> under the ISA² programme. 
+</p>
+<p>
+  The ISA² Programme of the European Commission was represented by <strong>Pavlina Fragkou</strong> and <strong>Seth van Hooland</strong>. 
+  <strong>Andrea Perego</strong> and <strong>Bert van Nuffelen</strong> were the editors of the specification. 
+</p>
+<p>
+  Contributors: Andreas Kuckartz, Antonio Rotundo, Danny Vandenbroucke, Fabian Kirstein, Franck Cotton, Hannes Reuter, Jakub Klímek, James Passmore, Matthias Palmér, Simon Cox.
+</p>
+  
 </section>
 
 <!-- Annexes -->


### PR DESCRIPTION
Added representatives, editors, contributors.

For the GeoDCAT-AP WG, a link was added to the members' page on Joinup, and the old table removed.

Co-authored-by: @andrea-perego & @bertvannuffelen